### PR TITLE
Initial Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,12 @@
+.dockerignore
+.env
+.gitattributes
+.gitignore
 analytics
+docker-compose.yaml
+Dockerfile
 Makefile
 Procfile
 README.md
 ROADMAP.md
 screenshot.png
-.gitattributes
-.gitignore
-.dockerignore
-.env

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+analytics
+Makefile
+Procfile
+README.md
+ROADMAP.md
+screenshot.png
+.gitattributes
+.gitignore
+.dockerignore
+.env

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,45 @@
+name: Create and publish Docker images
+
+on:
+  push:
+    branches: ['main']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout respository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # TODO: figure out versioning / releases
+          #   For now, every push to main will generate an image tagged with 'latest'
+          #   and the commit short hash.
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ venv.bak/
 .mypy_cache/
 .jsbeautifyrc
 
+analytics/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3-slim
+RUN groupadd -g 1000 bear && \
+  useradd -u 1000 -g 1000 -m -s /bin/bash bear && \
+  mkdir -p /app/data && \
+  chown -R bear:bear /app
+WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  curl \
+  && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+RUN chmod +x docker/entrypoint.sh docker/run.sh
+RUN mkdir -p /app/data
+EXPOSE 8000
+HEALTHCHECK --interval=60s --timeout=30s --start-period=15s --retries=3 CMD curl -f http://localhost:8000/script.js || exit 1
+ENTRYPOINT ["/app/docker/entrypoint.sh"]
+CMD ["/app/docker/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,22 @@
 FROM python:3-slim
-RUN groupadd -g 1000 bear && \
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  curl=7.88.1-10+deb12u8 \
+  && rm -rf /var/lib/apt/lists/* && \
+  groupadd -g 1000 bear && \
   useradd -u 1000 -g 1000 -m -s /bin/bash bear && \
   mkdir -p /app/data && \
   chown -R bear:bear /app
+
 WORKDIR /app
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  curl \
-  && rm -rf /var/lib/apt/lists/*
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-COPY . .
-RUN chmod +x docker/entrypoint.sh docker/run.sh
-RUN mkdir -p /app/data
+
+COPY --chown=bear:bear . .
+
+RUN pip install --no-cache-dir -r requirements.txt && \
+  chmod +x docker/entrypoint.sh docker/run.sh
+
 EXPOSE 8000
-HEALTHCHECK --interval=60s --timeout=30s --start-period=15s --retries=3 CMD curl -f http://localhost:8000/script.js || exit 1
+HEALTHCHECK --interval=60s --timeout=30s --start-period=15s --retries=3 \
+  CMD curl -f http://localhost:8000/script.js || exit 1
 ENTRYPOINT ["/app/docker/entrypoint.sh"]
 CMD ["/app/docker/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  curl=7.88.1-10+deb12u8 \
-  && rm -rf /var/lib/apt/lists/* && \
+  curl=7.88.1-10+deb12u8 && \
+  rm -rf /var/lib/apt/lists/* && \
   groupadd -g 1000 bear && \
   useradd -u 1000 -g 1000 -m -s /bin/bash bear && \
   mkdir -p /app/data && \

--- a/README.md
+++ b/README.md
@@ -83,17 +83,20 @@ A: The database is stored in a SQLite database file on your server. You can back
 **Q: Can I pay you to host my analytics?**  
 A: No, but if it's something you're interested in, let me know by commenting on [this issue](https://github.com/HermanMartinus/bearlytics/issues/1), and I may add it to [the roadmap](ROADMAP.md).
 
-## Self-hosting Guide
+## Self-hosting Guides
 
-This is a basic Django app that can be deployed to any platform that supports Django. I've chosen Dokku for this guide because it's easy to set up and manage, and I'm familiar with it.
+This is a basic Django app that can be deployed to any platform that supports Django.
 
-### Prerequisites
+### Dokku
+I've chosen Dokku for this guide because it's easy to set up and manage, and I'm familiar with it.
+
+#### Prerequisites
 
 - A Dokku server
 - Basic knowledge of terminal commands
 - A cup of coffee
 
-### Step 1: Dokku Setup 
+#### Step 1: Dokku Setup
 
 ```bash
 # Create the app
@@ -111,7 +114,7 @@ dokku config:set SALT_SECRET=your_very_secret_salt_here
 dokku config:set DEBUG=False
 ```
 
-### Step 2: Deploy
+#### Step 2: Deploy
 
 Add Dokku as a remote and commit and push your code
 ```bash
@@ -119,7 +122,7 @@ git remote add dokku dokku@your-server:analytics
 git push dokku main
 ```
 
-### Step 3: Add Your First Website
+#### Step 3: Add Your First Website
 
 1. Visit `https://your-analytics-domain.com`
 2. Create an account (if no user exists, the first user will be automatically promoted to admin)
@@ -127,6 +130,30 @@ git push dokku main
 4. Copy the tracking script
 5. Add it to your website's `<head>` section
 6. Watch those sweet, sweet analytics roll in
+
+### Docker
+Preliminary Docker support is available through the included [Dockerfile](Dockerfile). (Prebuilt images will be available soon™.)
+
+1. Clone this repo.
+2. Create a new directory called `analytics/` to store the data.
+3. Create a `.env` file with (at least):
+    ```shell
+    SECRET_KEY=your_django_secret_key
+    SALT_SECRET=your_secret_salt
+    ```
+4. Review [docker-compose.yaml](docker-compose.yaml) for any other needed changes, such as adjusting the `UID`/`GID` to match the ownership of the `analytics/` directory.
+5. Build and deploy the app:
+    ```shell
+    docker compose up -d --build
+    ```
+
+For production deployments, serve Bearlytics behind a reverse proxy like [Caddy](https://caddyserver.com/docs/quick-starts/reverse-proxy) or [nginx](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/). A Caddy configuration could be as simple as:
+
+```
+bearlytics.example.com {
+  reverse_proxy http://localhost:8000
+}
+```
 
 ## Tracking Script
 

--- a/README.md
+++ b/README.md
@@ -132,19 +132,40 @@ git push dokku main
 6. Watch those sweet, sweet analytics roll in
 
 ### Docker
-Preliminary Docker support is available through the included [Dockerfile](Dockerfile). (Prebuilt images will be available soon™.)
+For hosting with Docker Compose:
 
-1. Clone this repo.
-2. Create a new directory called `analytics/` to store the data.
+1. Create a directory to hold the configuration .
+    ```shell
+    mkdir -p /opt/bearlytics
+    ```
+2. Create a subfolder `analytics/` to store the data.
 3. Create a `.env` file with (at least):
     ```shell
     SECRET_KEY=your_django_secret_key
     SALT_SECRET=your_secret_salt
     ```
-4. Review [docker-compose.yaml](docker-compose.yaml) for any other needed changes, such as adjusting the `UID`/`GID` to match the ownership of the `analytics/` directory.
-5. Build and deploy the app:
+4. Review [docker-compose.yaml](docker-compose.yaml) for any other needed changes, such as adjusting the `UID`/`GID` to match the ownership of the `analytics/` directory:
+    ```yaml
+    services:
+      bearlytics:
+        image: ghcr.io/HermanMartinus/bearlytics:latest
+        ports:
+        - 8000:8000
+        volumes:
+        - ./analytics:/app/data
+        environment:
+          CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS:-http://localhost}
+          DB_PATH: ${DB_PATH:-/app/data/analytics.db}
+          DEBUG: False
+          SALT_SECRET: ${SALT_SECRET:?err}
+          SECRET_KEY: ${SECRET_KEY:?err}
+          UID: 1000
+          GID: 1000
+        restart: unless-stopped
+    ```
+5. Deploy the app:
     ```shell
-    docker compose up -d --build
+    docker compose up -d
     ```
 
 For production deployments, serve Bearlytics behind a reverse proxy like [Caddy](https://caddyserver.com/docs/quick-starts/reverse-proxy) or [nginx](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/). A Caddy configuration could be as simple as:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS:-http://localhost}
       DB_PATH: ${DB_PATH:-/app/data/analytics.db}
       DEBUG: False
-      SALT_SECRET: ${SALT_SECRET:-?err}
+      SALT_SECRET: ${SALT_SECRET:?err}
       SECRET_KEY: ${SECRET_KEY:?err}
       UID: 1000
       GID: 1000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+services:
+  bearlytics:
+    build: .
+    ports:
+    - 8000:8000
+    volumes:
+    - ./analytics:/app/data
+    environment:
+      CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS:-http://localhost}
+      DB_PATH: ${DB_PATH:-/app/data/analytics.db}
+      DEBUG: False
+      SALT_SECRET: ${SALT_SECRET:-?err}
+      SECRET_KEY: ${SECRET_KEY:?err}
+      UID: 1000
+      GID: 1000
+    restart: unless-stopped

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   bearlytics:
-    build: .
+    image: ghcr.io/HermanMartinus/bearlytics:latest
     ports:
     - 8000:8000
     volumes:
@@ -14,3 +14,4 @@ services:
       UID: 1000
       GID: 1000
     restart: unless-stopped
+

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,3 +9,4 @@ usermod -o -u "$UID" $USER
 chown -R $USER:$USER /app
 
 exec su $USER -c "$@"
+

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+export USER=bear
+UID=${UID:-1000}
+GID=${GID:-1000}
+groupmod -o -g "$GID" $USER
+usermod -o -u "$UID" $USER
+chown -R $USER:$USER /app
+
+exec su $USER -c "$@"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -6,3 +6,4 @@ python manage.py migrate
 
 # Start gunicorn
 exec gunicorn conf.wsgi --log-file - --bind 0.0.0.0:8000
+

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Run migrations first
+python manage.py migrate
+
+# Start gunicorn
+exec gunicorn conf.wsgi --log-file - --bind 0.0.0.0:8000


### PR DESCRIPTION
As discussed in #3, this adds initial support for deploying Bearlytics with Docker, and includes a GitHub Actions workflow to build the Docker image and publish it to the integrated GitHub registry on pushes to the `main` branch.

For now, images will be tagged with the short SHA of the corresponding commit and `latest`. This approach can be updated to match the project's versioning scheme as needed.

