### PR TITLE
Fix image pull reference in docker-compose.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ For hosting with Docker Compose:
     ```yaml
     services:
       bearlytics:
-        image: ghcr.io/HermanMartinus/bearlytics:latest
+        image: ghcr.io/hermanmartinus/bearlytics:latest
         ports:
         - 8000:8000
         volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   bearlytics:
-    image: ghcr.io/HermanMartinus/bearlytics:latest
+    image: ghcr.io/hermanmartinus/bearlytics:latest
     ports:
     - 8000:8000
     volumes:


### PR DESCRIPTION
Attempting a `docker compose pull` with the current configuration throws an error:

```
unable to get image 'ghcr.io/HermanMartinus/bearlytics:latest': Error response from daemon: invalid reference format: repository name (HermanMartinus/bearlytics) must be lowercase
```

This correctly sets the repository name so the image can be pulled successfully.