### PR TITLE
update: assume https for script embed url

### DIFF
--- a/project/templates/websites.html
+++ b/project/templates/websites.html
@@ -27,7 +27,7 @@
                         <input
                             type="text"
                             readonly
-                            value='<script data-site="{{ website.id }}" src="{{ request.scheme }}://{{ request.get_host }}/script.js" defer></script>'
+                            value='<script data-site="{{ website.id }}" src="https://{{ request.get_host }}/script.js" defer></script>'
                             class="w-full h-10 bg-gray-100 px-3 rounded border border-gray-200 text-gray-600 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300"
                         >
                     </div>


### PR DESCRIPTION
Auto-detecting the URI scheme isn't reliable when the container is served behind a reverse proxy. 

See #10.