### PR TITLE
ci: add build for arm64

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,6 +23,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96
@@ -40,6 +42,8 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
+          provenance: false # otherwise creates an "unknown/unknown" arch as well
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
Updated the action to also create an arm64 image.
Now I can easily test Bearlytics on my server!